### PR TITLE
Internal code review of schedin implementation of MSHARED-1344 Support for tsapolicyid and tsadigestalg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   </parent>
 
   <artifactId>maven-jarsigner</artifactId>
-  <version>3.0.1-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
 
   <name>Apache Maven Jarsigner</name>
   <description>A component to assist in signing jars.</description>

--- a/src/main/java/org/apache/maven/shared/jarsigner/JarSignerCommandLineBuilder.java
+++ b/src/main/java/org/apache/maven/shared/jarsigner/JarSignerCommandLineBuilder.java
@@ -173,6 +173,18 @@ public class JarSignerCommandLineBuilder {
             cli.createArg().setValue(tsaAlias);
         }
 
+        String tsapolicyid = request.getTsapolicyid();
+        if (StringUtils.isNotBlank(tsapolicyid)) {
+            cli.createArg().setValue("-tsapolicyid");
+            cli.createArg().setValue(tsapolicyid);
+        }
+
+        String tsadigestalg = request.getTsadigestalg();
+        if (StringUtils.isNotBlank(tsadigestalg)) {
+            cli.createArg().setValue("-tsadigestalg");
+            cli.createArg().setValue(tsadigestalg);
+        }
+
         File signedjar = request.getSignedjar();
         if (signedjar != null) {
             cli.createArg().setValue("-signedjar");

--- a/src/main/java/org/apache/maven/shared/jarsigner/JarSignerSignRequest.java
+++ b/src/main/java/org/apache/maven/shared/jarsigner/JarSignerSignRequest.java
@@ -29,34 +29,50 @@ import java.io.File;
 public class JarSignerSignRequest extends AbstractJarSignerRequest {
 
     /**
-     * See <a href="http://docs.oracle.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      */
     private String keypass;
 
     /**
-     * See <a href="http://docs.oracle.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      */
     private String sigfile;
 
     /**
-     * See <a href="http://docs.oracle.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      */
     private String tsaLocation;
 
     /**
-     * See <a href="http://docs.oracle.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      */
     private String tsaAlias;
 
     /**
-     * See <a href="http://docs.oracle.com/javase/6/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * The {@code -tsapolicyid} parameter, the OID that identifies the policy ID.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
+     *
+     * @since 3.1.0
+     */
+    private String tsapolicyid;
+
+    /**
+     * The {@code -tsadigestalg} parameter, the OID that identifies the policy ID. Only available in Java 11 and later.
+     * See <a href="https://docs.oracle.com/en/java/javase/11/tools/jarsigner.html#GUID-925E7A1B-B3F3-44D2-8B49-0B3FA2C54864__CCHIFIAD">options</a>.
+     *
+     * @since 3.1.0
+     */
+    private String tsadigestalg;
+
+    /**
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      */
     protected File signedjar;
 
     /**
      * Location of the extra certchain file to be used during signing.
      *
-     * See <a href="http://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      * @since 3.0.0
      */
     protected File certchain;
@@ -77,6 +93,14 @@ public class JarSignerSignRequest extends AbstractJarSignerRequest {
         return tsaAlias;
     }
 
+    public String getTsapolicyid() {
+        return tsapolicyid;
+    }
+
+    public String getTsadigestalg() {
+        return tsadigestalg;
+    }
+
     public void setKeypass(String keypass) {
         this.keypass = keypass;
     }
@@ -91,6 +115,14 @@ public class JarSignerSignRequest extends AbstractJarSignerRequest {
 
     public void setTsaAlias(String tsaAlias) {
         this.tsaAlias = tsaAlias;
+    }
+
+    public void setTsapolicyid(String tsapolicyid) {
+        this.tsapolicyid = tsapolicyid;
+    }
+
+    public void setTsadigestalg(String tsadigestalg) {
+        this.tsadigestalg = tsadigestalg;
     }
 
     public File getSignedjar() {

--- a/src/main/java/org/apache/maven/shared/jarsigner/JarSignerSignRequest.java
+++ b/src/main/java/org/apache/maven/shared/jarsigner/JarSignerSignRequest.java
@@ -39,11 +39,13 @@ public class JarSignerSignRequest extends AbstractJarSignerRequest {
     private String sigfile;
 
     /**
+     * The {@code -tsa} parameter, the URL to the Time Stamping Authority (TSA) server.
      * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      */
     private String tsaLocation;
 
     /**
+     * The {@code -tsacert} parameter, alias of the TSA public key certificate in the keystore that is in effect.
      * See <a href="https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jarsigner.html#CCHIFIAD">options</a>.
      */
     private String tsaAlias;
@@ -57,8 +59,9 @@ public class JarSignerSignRequest extends AbstractJarSignerRequest {
     private String tsapolicyid;
 
     /**
-     * The {@code -tsadigestalg} parameter, the OID that identifies the policy ID. Only available in Java 11 and later.
-     * See <a href="https://docs.oracle.com/en/java/javase/11/tools/jarsigner.html#GUID-925E7A1B-B3F3-44D2-8B49-0B3FA2C54864__CCHIFIAD">options</a>.
+     * The {@code -tsadigestalg} parameter, the message digest algorithm for TSA server to use. Only available in Java
+     * 11 and later. See
+     * <a href="https://docs.oracle.com/en/java/javase/11/tools/jarsigner.html">options</a>.
      *
      * @since 3.1.0
      */


### PR DESCRIPTION
This is an "internal" pull request/code review so that the code can be review by my colleague before a real pull request is created for the https://github.com/apache/maven-jarsigner project. In practice it is public, since I cloned the repo.


Implementation of https://issues.apache.org/jira/browse/MSHARED-1344. Will add the possibility to use `-tsapolicyid` and `-tsadigestalg`. Note that `-tsadigestalg` is not available in Java 8, but exist in Java 11.

I also increased the next build number to 3.1.0 since this is a new feature. 

When testing the `-tsadigestalg` look like it worked fine. But I could not find any any combination of TSA server/TSAPolicyId that worked. Here is an snippet example of the command line that is produced (with a non-working TSA server/TSAPolicyId combo):
```
-tsa http://timestamp.digicert.com -tsapolicyid 1.3.6.1.4.1.6449.1.3.5.2 -tsadigestalg SHA-512
```